### PR TITLE
up: work-todo 생성 시 필수 컬럼만 입력 가능한 기능 추가

### DIFF
--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -54,6 +54,7 @@ export class WorkTodo {
   @Column({
     type: "text",
     charset: "utf8mb4",
+    nullable: true,
   })
   explanation: string;
 

--- a/src/work-todo/work-todo.dto.ts
+++ b/src/work-todo/work-todo.dto.ts
@@ -56,8 +56,8 @@ export class WorkTodoDto implements WorkTodoType {
   @IsNotEmpty({ always: true, message: "title에 해당되는 값이 존재하지 않습니다." })
   title: string;
 
-  @IsString({ always: true })
-  @IsNotEmpty({ always: true, message: "explanation에 해당되는 값이 존재하지 않습니다." })
+  @IsString({})
+  @IsNotEmpty({ message: "explanation에 해당되는 값이 존재하지 않습니다." })
   explanation: string;
 
   @IsInt({ groups: ["generated"] })

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -1,7 +1,16 @@
 @Host = http://localhost:3003
 @Router = work-todos
 
-### work_todo 추가
+### work_todo 추가(필수)
+POST {{Host}}/{{Router}}
+Content-Type: application/json
+
+{
+    "courseId": 1,
+    "title": "나만의 할 일3"
+}
+
+### work_todo 추가(선택)
 POST {{Host}}/{{Router}}
 Content-Type: application/json
 


### PR DESCRIPTION
# 변경 내역

1. work-todo 테이블 내 explanation 컬럼을 nullable 하게 변경했습니다.
2. work-todo 생성 POST 요청 전송 시 필수값 컬럼을 제외한 요청을 todo service가 받아들이게 수정했습니다.
3. work-todo 생성 관련 양식을 적어둔 문서를 갱신했습니다.