### PR TITLE
Controller 코드에서 Service 코드 호출 시 json을 파라미터로 입력받게 수정

### DIFF
--- a/src/work-done/work-done-querystring.dto.ts
+++ b/src/work-done/work-done-querystring.dto.ts
@@ -1,0 +1,9 @@
+import { WorkDoneQuerystringType } from "./work-done-querystring.type";
+
+export class WorkDoneQuerystringDto implements WorkDoneQuerystringType {
+  constructor(courseId: number) {
+    this.courseId = courseId ?? undefined;
+  }
+
+  courseId: number;
+}

--- a/src/work-done/work-done-querystring.type.ts
+++ b/src/work-done/work-done-querystring.type.ts
@@ -1,0 +1,3 @@
+export type WorkDoneQuerystringType = {
+  courseId: number;
+};

--- a/src/work-done/work-done.controller.ts
+++ b/src/work-done/work-done.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Query,
 
 import { WorkDoneDto } from "./work-done.dto";
 import { WorkDoneService } from "./work-done.service";
+import { WorkDoneQuerystringDto } from "./work-done-querystring.dto";
 
 import { getErrorHttpStatusCode, getErrorMessage } from "src/common/lib/error";
 
@@ -30,8 +31,10 @@ export class WorkDoneController {
     let serviceResult: WorkDoneDto[];
 
     try {
+      const querystringInput = new WorkDoneQuerystringDto(courseId);
+
       // 할일 리스트 저장
-      serviceResult = await this.workDoneService.getWorkDonesByConditions(courseId);
+      serviceResult = await this.workDoneService.getWorkDonesByConditions(querystringInput);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -4,6 +4,7 @@ import { getRepository, Repository } from "typeorm";
 
 import { WorkDoneType } from "./work-done.type";
 import { WorkDoneDto } from "./work-done.dto";
+import { WorkDoneQuerystringDto } from "./work-done-querystring.dto";
 
 import { CRUDService } from "src/common/crud.service";
 
@@ -12,6 +13,7 @@ import { WorkTodo } from "src/entity/work-todo.entity";
 import { Course } from "src/entity/course.entity";
 
 import { WorkTodoService } from "src/work-todo/work-todo.service";
+import { WorkTodoQuerystringDto } from "src/work-todo/work-todo-querystring.dto";
 
 @Injectable()
 export class WorkDoneService extends CRUDService<WorkDone> {
@@ -46,16 +48,17 @@ export class WorkDoneService extends CRUDService<WorkDone> {
     await this.create(workDoneEntitiesInput);
   }
 
-  async getWorkDonesByConditions(courseId?: number): Promise<WorkDoneDto[]> {
+  async getWorkDonesByConditions(querystringInput: WorkDoneQuerystringDto): Promise<WorkDoneDto[]> {
     const workDoneDtoArrayResult = new Array<WorkDoneDto>();
     /*
       FROM    work_done AS wd
     */
     let queryString = getRepository(WorkDone).createQueryBuilder("wd");
 
-    if (courseId) {
+    if (querystringInput?.courseId) {
+      const workTodoQuerystringInput = new WorkTodoQuerystringDto(querystringInput.courseId);
       // courseId 값을 가지고 있는 WorkDoneDto 객체의 배열을 생성한다.
-      const wokrTodoDtoArrayResult = await this.workTodoService.getWorkTodosByConditions(courseId);
+      const wokrTodoDtoArrayResult = await this.workTodoService.getWorkTodosByConditions(workTodoQuerystringInput);
       const workTodoIdArray = new Array<number>();
       // number 배열을 workTodoDtoArrayResult로 부터 생성한다.
       for (const item of wokrTodoDtoArrayResult) {

--- a/src/work-todo/work-todo-querystring.dto.ts
+++ b/src/work-todo/work-todo-querystring.dto.ts
@@ -1,0 +1,9 @@
+import { WorkTodoQuerystringType } from "./work-todo-querystring.type";
+
+export class WorkTodoQuerystringDto implements WorkTodoQuerystringType {
+  constructor(courseId: number) {
+    this.courseId = courseId ?? undefined;
+  }
+
+  courseId: number;
+}

--- a/src/work-todo/work-todo-querystring.type.ts
+++ b/src/work-todo/work-todo-querystring.type.ts
@@ -1,0 +1,3 @@
+export type WorkTodoQuerystringType = {
+  courseId: number;
+};

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -3,6 +3,7 @@ import { Body, Controller, Delete, Get, HttpException, Param, ParseIntPipe, Post
 import { WorkTodoService } from "./work-todo.service";
 import { WorkTodoGetDto } from "./work-todo-get.dto";
 import { WorkTodoPostDto } from "./work-todo-post.dto";
+import { WorkTodoQuerystringDto } from "./work-todo-querystring.dto";
 
 import { getErrorHttpStatusCode, getErrorMessage } from "src/common/lib/error";
 import { CRUDController } from "src/common/crud.controller";
@@ -37,8 +38,10 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
     let serviceResult: WorkTodoGetDto[];
 
     try {
+      const querystringInput = new WorkTodoQuerystringDto(courseId);
+
       // 할일 리스트 저장
-      serviceResult = await this.workTodoService.getWorkTodosByConditions(courseId);
+      serviceResult = await this.workTodoService.getWorkTodosByConditions(querystringInput);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -4,6 +4,7 @@ import { getRepository, Repository } from "typeorm";
 
 import { WorkTodoGetDto } from "./work-todo-get.dto";
 import { WorkTodoPostDto } from "./work-todo-post.dto";
+import { WorkTodoQuerystringDto } from "./work-todo-querystring.dto";
 
 import { CRUDService } from "src/common/crud.service";
 
@@ -85,7 +86,7 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     await this.repeatedDaysOfTheWeekService.create(repeatedDaysOfTheWeekEntities);
   }
 
-  async getWorkTodosByConditions(courseId?: number): Promise<WorkTodoGetDto[]> {
+  async getWorkTodosByConditions(querystringInput: WorkTodoQuerystringDto): Promise<WorkTodoGetDto[]> {
     const blankWorkTodoEntities = new Array<WorkTodo>();
     const workTodoEntitiesResult = await this.find(blankWorkTodoEntities);
     const workTodoGetDtoArrayResult = new Array<WorkTodoGetDto>();
@@ -104,8 +105,8 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
         .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
         .leftJoinAndMapMany("wt", RepeatedDaysOfTheWeek, "rdotw", "wt.id = rdotw.work_todo_id")
         .where("wt.id = :workTodoId", { workTodoId: workTodoEntity.id });
-      if (courseId) {
-        queryString = queryString.andWhere("c.id = :courseId", { courseId: courseId });
+      if (querystringInput?.courseId) {
+        queryString = queryString.andWhere("c.id = :courseId", { courseId: querystringInput.courseId });
       }
       const joinResult = await queryString.getRawMany();
 


### PR DESCRIPTION
# 변경 내역

1. Controller 코드에서 유저의 querystring 입력을 객체로 가공해 Service 코드를 호출하게 변경

## 목적

1. Service 코드의 메소드 파라미터가 복잡해 지는 것을 방지
2. Service 코드에서 유저의 입력값 처리시 그 값을 가지고 있는 객체 key값이 유저의 querystring 입력 이라는 것을 명시적으로 알 수 있음

# 테스트 방법

1. QA 배포가 완료된 다음 기존 방식대로 querystring으로 GET 하는 요청을 날려서 스펙대로 정상 동작하는지 확인