### PR TITLE
work_todo 테이블 내 user_id 컬럼 추가

### DIFF
--- a/src/entity/course.entity.ts
+++ b/src/entity/course.entity.ts
@@ -62,7 +62,7 @@ export class Course {
   @JoinColumn({ name: "color" })
   color: Color;
 
-  @Column({ nullable: true, name: "creator_id" })
+  @Column({ name: "creator_id" })
   creatorId: number;
 
   @Column({

--- a/src/entity/work-done.entity.ts
+++ b/src/entity/work-done.entity.ts
@@ -41,7 +41,7 @@ export class WorkDone {
   })
   content: string;
 
-  @Column({ nullable: true, name: "user_id" })
+  @Column({ name: "user_id" })
   userId: number;
 
   @ManyToOne(() => WorkTodo, (workToDo) => workToDo.id, {

--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -4,7 +4,7 @@ import { Course } from "./course.entity";
 
 @Entity({})
 export class WorkTodo {
-  constructor(id?: number, courseId?: Course, recurringCycleDate?: number, title?: string, explanation?: string, activeDate?: Date) {
+  constructor(id?: number, courseId?: Course, recurringCycleDate?: number, title?: string, explanation?: string, activeDate?: Date, userId?: number) {
     if (id) {
       this.id = id;
     }
@@ -22,6 +22,9 @@ export class WorkTodo {
     }
     if (activeDate) {
       this.activeDate = activeDate;
+    }
+    if (userId) {
+      this.userId = userId;
     }
   }
 

--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -60,4 +60,9 @@ export class WorkTodo {
     name: "active_date",
   })
   activeDate: Date;
+
+  @Column({
+    name: "user_id",
+  })
+  userId: number;
 }

--- a/src/work-todo/work-todo.dto.ts
+++ b/src/work-todo/work-todo.dto.ts
@@ -13,6 +13,7 @@ export class WorkTodoDto implements WorkTodoType {
       this.id = workTodoTypeInput.id ?? undefined;
       this.recurringCycleDate = workTodoTypeInput.recurringCycleDate ?? undefined;
       this.title = workTodoTypeInput.title ?? undefined;
+      this.userId = workTodoTypeInput.userId ?? undefined;
     }
   }
 
@@ -25,6 +26,7 @@ export class WorkTodoDto implements WorkTodoType {
     workTodoDto.explanation = workTodoEntityInput.explanation ?? undefined;
     workTodoDto.activeDate = workTodoEntityInput.activeDate ?? undefined;
     workTodoDto.courseId = workTodoEntityInput.courseId?.id ?? undefined;
+    workTodoDto.userId = workTodoEntityInput.userId ?? undefined;
 
     return workTodoDto;
   }
@@ -49,4 +51,7 @@ export class WorkTodoDto implements WorkTodoType {
   @IsInt({ always: true, message: "코스의 id값이 비어있습니다." })
   @IsNotEmpty({ always: true, message: "코스의 id값이 비어있습니다." })
   courseId: number;
+
+  @IsInt({ always: true, message: "userId 값이 비어있습니다." })
+  userId: number;
 }

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -45,7 +45,8 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
       workTodoPostDtoInput.recurringCycleDate,
       workTodoPostDtoInput.title,
       workTodoPostDtoInput.explanation,
-      workTodoPostDtoInput.activeDate
+      workTodoPostDtoInput.activeDate,
+      workTodoPostDtoInput.userId
     );
 
     workTodoEntities.push(workTodoEntity);

--- a/src/work-todo/work-todo.type.ts
+++ b/src/work-todo/work-todo.type.ts
@@ -5,4 +5,5 @@ export type WorkTodoType = {
   explanation?: string;
   activeDate: Date;
   courseId: number;
+  userId: number;
 };


### PR DESCRIPTION
# 변경 내역

1. work_todo 테이블 내 user_id 컬럼을 추가했습니다.
2. work-todo의 DTO, Type 코드에 userId 속성을 추가했습니다.
3. course 테이블의 creator_id 컬럼을 not nullable 하게 변경했습니다.
4. work_done 테이블 내 user_id 컬럼을 not nullable 하게 변경했습니다.

# 변경 이유

1. @algo2000 @Seungup 님과 회의 결과 work_todo 테이블에도 API Gateway에서 JWT 값을 파싱한 결과가 입력되어야 한다는 결론에 이르었습니다.
2. course, work-done 입력시 userId 값을 JWT에서 무조껀 입력하는 기능이 API Gateway에 추가되어 user_id 컬럼을 not nullable 하게 변경할 필요가 있습니다.

# 테스트 방법

1. API gateway에서 work_todo를 입력하는 API endpoint를 호출한 다음, JWT 디코딩 된 값이 정상적으로 입력되는지 확인합니다.