### PR TITLE
Get, Delete 요청시 userId를 query string에서 가져와 필터링 하는 기능 추가

### DIFF
--- a/src/common/lib/error.ts
+++ b/src/common/lib/error.ts
@@ -11,8 +11,9 @@ export function getErrorMessage(error: any): string {
   if (isAxiosError(error)) {
     if (error.response.data !== undefined) {
       errorResult = error.response.data;
+    } else {
+      errorResult = error.message;
     }
-    errorResult = error.message;
   }
 
   return errorResult;

--- a/src/course/course-querystring.dto.ts
+++ b/src/course/course-querystring.dto.ts
@@ -1,0 +1,9 @@
+import { CourseQuerystringType } from "./course-querystring.type";
+
+export class CourseQuerystringDto implements CourseQuerystringType {
+  constructor(userId: number) {
+    this.userId = userId ?? undefined;
+  }
+
+  userId: number;
+}

--- a/src/course/course-querystring.type.ts
+++ b/src/course/course-querystring.type.ts
@@ -1,0 +1,3 @@
+export type CourseQuerystringType = {
+  userId: number;
+};

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Delete, Get, HttpException, Param, ParseIntPipe, Post, ValidationPipe } from "@nestjs/common";
+import { Body, Controller, Delete, Get, HttpException, Param, ParseIntPipe, Post, Query, ValidationPipe } from "@nestjs/common";
 
 import { CourseService } from "./course.service";
 import { CoursePostDto } from "./course-post.dto";
 import { CourseGetDto } from "./course-get.dto";
+import { CourseQuerystringDto } from "./course-querystring.dto";
 
 import { getErrorHttpStatusCode, getErrorMessage } from "src/common/lib/error";
 import { CRUDController } from "src/common/crud.controller";
@@ -33,12 +34,14 @@ export class CourseController extends CRUDController<Course> {
   }
 
   @Get()
-  async getAllCourses() {
+  async getAllCourses(@Query("userId") userId: number) {
     let serviceResult: CourseGetDto[];
 
     try {
+      const querystringInput = new CourseQuerystringDto(userId);
+
       // 코스 리스트 저장
-      serviceResult = await this.courseService.getAllCourses();
+      serviceResult = await this.courseService.getAllCourses(querystringInput);
     } catch (error) {
       // 동작에 실패한 경우 Catch 구문에 예외를 넘김
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -17,7 +17,7 @@ export class CourseController extends CRUDController<Course> {
   }
 
   @Post()
-  async createCourse(@Body(new ValidationPipe({ groups: ["userCreate"] })) coursePostDtoInput: CoursePostDto) {
+  async createCourse(@Body(new ValidationPipe({ groups: ["userInput"] })) coursePostDtoInput: CoursePostDto) {
     try {
       await this.courseService.createCourse(coursePostDtoInput);
       await this.courseService.createNewTags(coursePostDtoInput.tags);

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -55,9 +55,9 @@ export class CourseController extends CRUDController<Course> {
   }
 
   @Delete(":id")
-  async deleteCourses(@Param("id", ParseIntPipe) id: number) {
+  async deleteCourses(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
     try {
-      await this.courseService.deleteCourse(id);
+      await this.courseService.deleteCourse(userId, id);
     } catch (error) {
       // 동작에 실패한 경우 Catch 구문에 예외를 넘김
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/course/course.dto.ts
+++ b/src/course/course.dto.ts
@@ -47,7 +47,7 @@ export class CourseDto implements CourseType {
   @IsNotEmpty({ always: true })
   color: string;
 
-  @IsInt()
+  @IsInt({ always: true, message: "creatorId 값이 비어있습니다." })
   creatorId: number;
 
   @IsDate({ groups: ["userUpdate"] })

--- a/src/course/course.http
+++ b/src/course/course.http
@@ -24,4 +24,4 @@ Content-Type: application/json
 }
 
 ### course 삭제
-DELETE {{Host}}/{{Router}}/courses/1
+DELETE {{Host}}/{{Router}}/courses/1?userId=

--- a/src/course/course.http
+++ b/src/course/course.http
@@ -1,9 +1,8 @@
 @Host = http://localhost:3003
 @Router = courses
 
-### course 정보 전체 조회
-GET {{Host}}/{{Router}}
-Content-Type: application/json
+### course 리스트 조회
+GET {{Host}}/{{Router}}?userId=
 
 ### course 생성
 POST {{Host}}/{{Router}}

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -103,9 +103,9 @@ export class CourseService extends CRUDService<Course> {
     return courseGetDtoArrayResult;
   }
 
-  async deleteCourse(id: number): Promise<void> {
+  async deleteCourse(userId: number, id: number): Promise<void> {
     const courseEntities = new Array<Course>();
-    const courseEntity = new Course(id, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
+    const courseEntity = new Course(id, undefined, undefined, userId, undefined, undefined, undefined, undefined, undefined);
 
     courseEntities.push(courseEntity);
     const selectResult = await this.find(courseEntities);

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -5,6 +5,7 @@ import { getRepository, Repository } from "typeorm";
 import { CourseDto } from "./course.dto";
 import { CourseGetDto } from "./course-get.dto";
 import { CoursePostDto } from "./course-post.dto";
+import { CourseQuerystringDto } from "./course-querystring.dto";
 
 import { CRUDService } from "src/common/crud.service";
 
@@ -62,10 +63,10 @@ export class CourseService extends CRUDService<Course> {
     await this.create(courseEntities);
   }
 
-  async getAllCourses(): Promise<CourseGetDto[]> {
-    // TypeORM 사용해서 검색을 할 때 조건을 주지 않고 전체 검색을 위한 Course entity 배열
-    const blankCourseEntities: Course[] = new Array<Course>();
-    const courseEntitiesResult = await this.find(blankCourseEntities);
+  async getAllCourses(querystringInput: CourseQuerystringDto): Promise<CourseGetDto[]> {
+    const courseEntitiesFilter: Course[] = new Array<Course>();
+    courseEntitiesFilter.push(new Course(undefined, undefined, undefined, querystringInput.userId, undefined, undefined, undefined, undefined, undefined));
+    const courseEntitiesResult = await this.find(courseEntitiesFilter);
     // DTO 형태로 반환하기 위한 CourseDTO 배열
     const courseGetDtoArrayResult = new Array<CourseGetDto>();
 

--- a/src/work-done/work-done-querystring.dto.ts
+++ b/src/work-done/work-done-querystring.dto.ts
@@ -1,9 +1,12 @@
 import { WorkDoneQuerystringType } from "./work-done-querystring.type";
 
 export class WorkDoneQuerystringDto implements WorkDoneQuerystringType {
-  constructor(courseId: number) {
+  constructor(userId: number, courseId?: number) {
+    this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
   }
 
-  courseId: number;
+  userId: number;
+
+  courseId?: number;
 }

--- a/src/work-done/work-done-querystring.type.ts
+++ b/src/work-done/work-done-querystring.type.ts
@@ -1,3 +1,4 @@
 export type WorkDoneQuerystringType = {
-  courseId: number;
+  userId: number;
+  courseId?: number;
 };

--- a/src/work-done/work-done.controller.ts
+++ b/src/work-done/work-done.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Query, ValidationPipe } from "@nestjs/common";
+import { Body, Controller, Delete, Get, HttpException, Param, ParseIntPipe, Post, Query, ValidationPipe } from "@nestjs/common";
 
 import { WorkDoneDto } from "./work-done.dto";
 import { WorkDoneService } from "./work-done.service";
@@ -61,5 +61,20 @@ export class WorkDoneController {
     }
 
     return serviceResult;
+  }
+
+  @Delete(":id")
+  async deleteWorkDone(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
+    try {
+      await this.workDoneService.deleteWorkDone(userId, id);
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      // API에 에러를 토스
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return;
   }
 }

--- a/src/work-done/work-done.controller.ts
+++ b/src/work-done/work-done.controller.ts
@@ -27,11 +27,11 @@ export class WorkDoneController {
 
   // TODO: Custom pipe 만들어 param을 선택 사항 가능하게 만들기
   @Get()
-  async getWorkTodosByConditions(@Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(@Query("userId") userId: number, @Query("courseId") courseId?: number) {
     let serviceResult: WorkDoneDto[];
 
     try {
-      const querystringInput = new WorkDoneQuerystringDto(courseId);
+      const querystringInput = new WorkDoneQuerystringDto(userId, courseId);
 
       // 할일 리스트 저장
       serviceResult = await this.workDoneService.getWorkDonesByConditions(querystringInput);

--- a/src/work-done/work-done.controller.ts
+++ b/src/work-done/work-done.controller.ts
@@ -47,11 +47,11 @@ export class WorkDoneController {
   }
 
   @Get(":id")
-  async getWorkDone(@Param("id", ParseIntPipe) id: number) {
+  async getWorkDone(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
     let serviceResult: WorkDoneDto;
 
     try {
-      serviceResult = await this.workDoneService.getWorkDone(id);
+      serviceResult = await this.workDoneService.getWorkDone(userId, id);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/work-done/work-done.dto.ts
+++ b/src/work-done/work-done.dto.ts
@@ -40,7 +40,7 @@ export class WorkDoneDto implements WorkDoneType {
   @IsNotEmpty({ always: true, message: "content 값이 비어있습니다." })
   content: string;
 
-  //   @IsInt({ groups: ["userInput"] })
+  @IsInt({ always: true, message: "userId 값이 비어있습니다." })
   userId: number;
 
   @IsInt({ groups: ["userInput"] })

--- a/src/work-done/work-done.http
+++ b/src/work-done/work-done.http
@@ -22,4 +22,4 @@ GET {{Host}}/{{Router}}?userId=&courseId=
 GET {{Host}}/{{Router}}/1
 
 ### work_done 삭제
-DELETE {{Host}}/{{Router}}/1
+DELETE {{Host}}/{{Router}}/1?userId=

--- a/src/work-done/work-done.http
+++ b/src/work-done/work-done.http
@@ -13,10 +13,10 @@ Content-Type: application/json
 }
 
 ### work_done 전체 리스트 가져오기
-GET {{Host}}/{{Router}}
+GET {{Host}}/{{Router}}?userId=
 
 ### work_done 리스트 가져오기
-GET {{Host}}/{{Router}}?courseId=1
+GET {{Host}}/{{Router}}?userId=&courseId=
 
 ### work_done 1개 가져오기
 GET {{Host}}/{{Router}}/1

--- a/src/work-done/work-done.http
+++ b/src/work-done/work-done.http
@@ -19,7 +19,7 @@ GET {{Host}}/{{Router}}?userId=
 GET {{Host}}/{{Router}}?userId=&courseId=
 
 ### work_done 1개 가져오기
-GET {{Host}}/{{Router}}/1
+GET {{Host}}/{{Router}}/1?userId=
 
 ### work_done 삭제
 DELETE {{Host}}/{{Router}}/1?userId=

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -130,4 +130,19 @@ export class WorkDoneService extends CRUDService<WorkDone> {
 
     return workDoneEntityResult;
   }
+
+  async deleteWorkDone(userId: number, id: number): Promise<void> {
+    // 검색을 위한 객체
+    const workDoneEntitiesInput = new Array<WorkDone>();
+    const workDoneEntityInput = new WorkDone(id, undefined, undefined, userId, undefined, undefined);
+
+    workDoneEntitiesInput.push(workDoneEntityInput);
+    const workTodoFindResult = await this.find(workDoneEntitiesInput);
+
+    if (workTodoFindResult.length === 0) {
+      throw new HttpException({ data: "조건을 만족하는 데이터가 없습니다.", status: HttpStatus.BAD_REQUEST }, HttpStatus.BAD_REQUEST);
+    }
+
+    await this.delete(workDoneEntitiesInput);
+  }
 }

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -59,31 +59,28 @@ export class WorkDoneService extends CRUDService<WorkDone> {
     */
     let sqlQueryString = getRepository(WorkDone).createQueryBuilder("wd");
 
-    if (querystringInput?.courseId) {
-      const workTodoQuerystringInput = new WorkTodoQuerystringDto(querystringInput.userId, querystringInput.courseId);
-      // courseId 값을 가지고 있는 WorkDoneDto 객체의 배열을 생성한다.
-      const wokrTodoDtoArrayResult = await this.workTodoService.getWorkTodosByConditions(workTodoQuerystringInput);
-      if (wokrTodoDtoArrayResult.length === 0) {
-        throw new HttpException({ data: "workTodo의 id 값을 만족하는 데이터가 없습니다.", status: HttpStatus.BAD_REQUEST }, HttpStatus.BAD_REQUEST);
-      }
+    const workTodoQuerystringInput = new WorkTodoQuerystringDto(querystringInput.userId, querystringInput.courseId);
+    const wokrTodoDtoArrayResult = await this.workTodoService.getWorkTodosByConditions(workTodoQuerystringInput);
+    if (wokrTodoDtoArrayResult.length === 0) {
+      throw new HttpException({ data: "workTodo의 id 값을 만족하는 데이터가 없습니다.", status: HttpStatus.BAD_REQUEST }, HttpStatus.BAD_REQUEST);
+    }
 
-      const workTodoIdArray = new Array<number>();
-      // number 배열을 workTodoDtoArrayResult로 부터 생성한다.
-      for (const item of wokrTodoDtoArrayResult) {
-        workTodoIdArray.push(item.id);
-      }
+    const workTodoIdArray = new Array<number>();
+    // number 배열을 workTodoDtoArrayResult로 부터 생성한다.
+    for (const item of wokrTodoDtoArrayResult) {
+      workTodoIdArray.push(item.id);
+    }
 
-      /*
+    /*
                 INNER JOIN work_todo wt on wd.work_todo_id = wt.id
                 INNER JOIN course c on wt.course_id = c.id
         WHERE   wd.work_todo_id IN (?);
       */
-      sqlQueryString = sqlQueryString
-        .innerJoinAndMapMany("wd", WorkTodo, "wt", "wd.work_todo_id = wt.id")
-        .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
-        .where("wd.user_id = :userId", { userId: querystringInput.userId })
-        .andWhere("wd.work_todo_id in (:workTodoIds)", { workTodoIds: workTodoIdArray });
-    }
+    sqlQueryString = sqlQueryString
+      .innerJoinAndMapMany("wd", WorkTodo, "wt", "wd.work_todo_id = wt.id")
+      .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
+      .where("wd.user_id = :userId", { userId: querystringInput.userId })
+      .andWhere("wd.work_todo_id in (:workTodoIds)", { workTodoIds: workTodoIdArray });
 
     // query string 을 사용해 SELECT 수행
     /*

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -109,10 +109,10 @@ export class WorkDoneService extends CRUDService<WorkDone> {
     return workDoneDtoArrayResult;
   }
 
-  async getWorkDone(id: number) {
+  async getWorkDone(userId: number, id: number) {
     // 검색을 위한 객체
     const workDoneEntitiesInput = new Array<WorkDone>();
-    const workDoneEntityInput = new WorkDone(id, undefined, undefined, undefined, undefined, undefined);
+    const workDoneEntityInput = new WorkDone(id, undefined, undefined, userId, undefined, undefined);
 
     workDoneEntitiesInput.push(workDoneEntityInput);
 

--- a/src/work-todo/work-todo-querystring.dto.ts
+++ b/src/work-todo/work-todo-querystring.dto.ts
@@ -1,9 +1,12 @@
 import { WorkTodoQuerystringType } from "./work-todo-querystring.type";
 
 export class WorkTodoQuerystringDto implements WorkTodoQuerystringType {
-  constructor(courseId: number) {
+  constructor(userId: number, courseId: number) {
+    this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
   }
 
-  courseId: number;
+  userId: number;
+
+  courseId?: number;
 }

--- a/src/work-todo/work-todo-querystring.type.ts
+++ b/src/work-todo/work-todo-querystring.type.ts
@@ -1,3 +1,4 @@
 export type WorkTodoQuerystringType = {
-  courseId: number;
+  userId: number;
+  courseId?: number;
 };

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -54,9 +54,9 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
   }
 
   @Delete(":id")
-  async deleteWorkTodo(@Param("id", ParseIntPipe) id: number) {
+  async deleteWorkTodo(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
     try {
-      await this.workTodoService.deleteWorkTodo(id);
+      await this.workTodoService.deleteWorkTodo(userId, id);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -34,11 +34,11 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
 
   // TODO: Custom pipe 만들어 param을 선택 사항 가능하게 만들기
   @Get()
-  async getWorkTodosByConditions(@Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(@Query("userId") userId: number, @Query("courseId") courseId?: number) {
     let serviceResult: WorkTodoGetDto[];
 
     try {
-      const querystringInput = new WorkTodoQuerystringDto(courseId);
+      const querystringInput = new WorkTodoQuerystringDto(userId, courseId);
 
       // 할일 리스트 저장
       serviceResult = await this.workTodoService.getWorkTodosByConditions(querystringInput);

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -8,7 +8,8 @@ Content-Type: application/json
 {
     "courseId": 1,
     "title": "나만의 할 일1",
-    "repeatedDaysOfTheWeek": []
+    "repeatedDaysOfTheWeek": [],
+    "userId": 1
 }
 
 ### work_todo 추가(선택)
@@ -21,14 +22,15 @@ Content-Type: application/json
     "repeatedDaysOfTheWeek": [1, 2, 3],
     "activeDate": "2021-11-05T08:50:00.12",
     "recurringCycleDate": 1,
-    "explanation": "나만의 할 일 설명1"
+    "explanation": "나만의 할 일 설명1",
+    "userId": 1
 }
 
 ### work_todo 전체 리스트 가져오기
-GET {{Host}}/{{Router}}
+GET {{Host}}/{{Router}}?userId=
 
 ### work_todo 조건에 알맞은 리스트 가져오기
-GET {{Host}}/{{Router}}?courseId=1
+GET {{Host}}/{{Router}}?userId=&courseId=1
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/1

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -33,4 +33,4 @@ GET {{Host}}/{{Router}}?userId=
 GET {{Host}}/{{Router}}?userId=&courseId=1
 
 ### work_todo 삭제
-DELETE {{Host}}/{{Router}}/1
+DELETE {{Host}}/{{Router}}/1?userid=

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -133,10 +133,10 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     return workTodoGetDtoArrayResult;
   }
 
-  async deleteWorkTodo(id: number): Promise<void> {
+  async deleteWorkTodo(userId: number, id: number): Promise<void> {
     // 검색을 위한 객체
     const workTodoEntitiesInput = new Array<WorkTodo>();
-    const workTodoEntityInput = new WorkTodo(id, undefined, undefined, undefined, undefined, undefined);
+    const workTodoEntityInput = new WorkTodo(id, undefined, undefined, undefined, undefined, undefined, userId);
 
     workTodoEntitiesInput.push(workTodoEntityInput);
     const workTodoFindResult = await this.find(workTodoEntitiesInput);

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -88,11 +88,13 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
   }
 
   async getWorkTodosByConditions(querystringInput: WorkTodoQuerystringDto): Promise<WorkTodoGetDto[]> {
-    const blankWorkTodoEntities = new Array<WorkTodo>();
-    const workTodoEntitiesResult = await this.find(blankWorkTodoEntities);
+    const workTodoEntitiesFilter = new Array<WorkTodo>();
+    workTodoEntitiesFilter.push(new WorkTodo(undefined, undefined, undefined, undefined, undefined, undefined, querystringInput.userId));
+    const workTodoEntitiesFilteredResult = await this.find(workTodoEntitiesFilter);
+
     const workTodoGetDtoArrayResult = new Array<WorkTodoGetDto>();
 
-    for (const workTodoEntity of workTodoEntitiesResult) {
+    for (const workTodoEntity of workTodoEntitiesFilteredResult) {
       /*
         SELECT *
         FROM work_todo
@@ -101,15 +103,15 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
         WHERE work_todo.id = ?
           AND c.id = ?
       */
-      let queryString = getRepository(WorkTodo)
+      let sqlQueryString = getRepository(WorkTodo)
         .createQueryBuilder("wt")
         .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
         .leftJoinAndMapMany("wt", RepeatedDaysOfTheWeek, "rdotw", "wt.id = rdotw.work_todo_id")
         .where("wt.id = :workTodoId", { workTodoId: workTodoEntity.id });
       if (querystringInput?.courseId) {
-        queryString = queryString.andWhere("c.id = :courseId", { courseId: querystringInput.courseId });
+        sqlQueryString = sqlQueryString.andWhere("c.id = :courseId", { courseId: querystringInput.courseId });
       }
-      const joinResult = await queryString.getRawMany();
+      const joinResult = await sqlQueryString.getRawMany();
 
       if (joinResult.length) {
         // 특정 courseId, worktodoId를 만족하는 결과에서 요일 배열 생성하기


### PR DESCRIPTION
# 변경 내역

1. Todo service 내부의 Table들에 대한 HTTP Get 요청시 query string에서 userId 값을 가져와 필터링 하는 기능 추가
2. Todo servie 내부의 Table들에 대한 HTTP Delete 요청시 query string에서 userId 값을 가져와 필터링 하는 기능 추가
3. work_done 테이블 삭제 기능 추가
2. 에러 반환 코드 내부의 if문을 논리적으로 들어가지 못해 적절한 에러 메세지가 반환되지 못하던 문제 수정

# 변경 사유

1. 다른 유저의 데이터를 볼 수 없게 하기 위해서
2. 다른 유저의 데이터를 삭제할 수 없게 하기 위해서
2. 추후 데이터 가공 기능 추가시 뼈대가 되는 데이터를 최소화 하여 DB, Server 단에서의 컴퓨팅 자원을 절약하기 위해

# 테스트 방법

1. API Gateway에서 HTTP Get 요청시 JWT 토큰 값을 header에 넣어 해당 유저의 데이터만 반환되는지 확인합니다.
2. API Gateway에서 HTTP Delete 요청시 JWT 토큰 값을 header에 넣어 해당 유저의 데이터가 삭제되는지 확인합니다.