### PR TITLE
work-todo 조건에 따라 리스트 조회시 SQL 쿼리 1회 실행으로 변경

### DIFF
--- a/src/entity/course.entity.ts
+++ b/src/entity/course.entity.ts
@@ -18,13 +18,13 @@ export class Course {
     if (id) {
       this.id = id;
     }
-    if (originalCourseId && originalCourseId.id !== undefined) {
+    if (originalCourseId?.id) {
       this.originalCourseId = originalCourseId;
     }
     if (color) {
       this.color = color;
     }
-    if (creatorId !== undefined) {
+    if (creatorId) {
       this.creatorId = creatorId;
     }
     if (startDate) {

--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -8,7 +8,7 @@ export class WorkTodo {
     if (id) {
       this.id = id;
     }
-    if (courseId && courseId.id !== undefined) {
+    if (courseId?.id) {
       this.courseId = courseId;
     }
     if (recurringCycleDate) {

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -30,7 +30,7 @@ Content-Type: application/json
 GET {{Host}}/{{Router}}?userId=
 
 ### work_todo 조건에 알맞은 리스트 가져오기
-GET {{Host}}/{{Router}}?userId=&courseId=1
+GET {{Host}}/{{Router}}?userId=&courseId=
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/1?userid=


### PR DESCRIPTION
# 변경 내역

1. work_todo 테이블을 타 테이블과 join 후 가져올때 반복질의 하던 코드를 1회 질의로 변경
2. course, work-wodo entity 코드 내부의 if 분기문 리펙토링

# 변경 이유

1. 의미없는 반복질의로 인한 DB 자원 낭비 억제

# 테스트 방법

1. work_todo 리스트를 가져오는 API endpoint를 호출할 때 querystring과 함께 호출하여 기대한 데이터가 반환되는지 확인합니다.