### PR TITLE
반복 일수에 따라 반복되는 work-todo 리스트 가져오는 기능 추가, userId 필수여부 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,6 +2885,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
+      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "cross-env": "^7.0.3",
+    "date-fns": "^2.25.0",
     "joi": "^17.4.2",
     "mysql2": "^2.3.2",
     "reflect-metadata": "^0.1.13",

--- a/src/course/course-querystring.dto.ts
+++ b/src/course/course-querystring.dto.ts
@@ -1,9 +1,9 @@
 import { CourseQuerystringType } from "./course-querystring.type";
 
 export class CourseQuerystringDto implements CourseQuerystringType {
-  constructor(userId: number) {
+  constructor(userId?: number) {
     this.userId = userId ?? undefined;
   }
 
-  userId: number;
+  userId?: number;
 }

--- a/src/course/course-querystring.type.ts
+++ b/src/course/course-querystring.type.ts
@@ -1,3 +1,3 @@
 export type CourseQuerystringType = {
-  userId: number;
+  userId?: number;
 };

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -34,7 +34,7 @@ export class CourseController extends CRUDController<Course> {
   }
 
   @Get()
-  async getAllCourses(@Query("userId") userId: number) {
+  async getAllCourses(@Query("userId") userId?: number) {
     let serviceResult: CourseGetDto[];
 
     try {

--- a/src/work-done/work-done-querystring.dto.ts
+++ b/src/work-done/work-done-querystring.dto.ts
@@ -1,12 +1,12 @@
 import { WorkDoneQuerystringType } from "./work-done-querystring.type";
 
 export class WorkDoneQuerystringDto implements WorkDoneQuerystringType {
-  constructor(userId: number, courseId?: number) {
+  constructor(userId?: number, courseId?: number) {
     this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
   }
 
-  userId: number;
+  userId?: number;
 
   courseId?: number;
 }

--- a/src/work-done/work-done-querystring.type.ts
+++ b/src/work-done/work-done-querystring.type.ts
@@ -1,4 +1,4 @@
 export type WorkDoneQuerystringType = {
-  userId: number;
+  userId?: number;
   courseId?: number;
 };

--- a/src/work-done/work-done.controller.ts
+++ b/src/work-done/work-done.controller.ts
@@ -27,7 +27,7 @@ export class WorkDoneController {
 
   // TODO: Custom pipe 만들어 param을 선택 사항 가능하게 만들기
   @Get()
-  async getWorkTodosByConditions(@Query("userId") userId: number, @Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(@Query("userId") userId?: number, @Query("courseId") courseId?: number) {
     let serviceResult: WorkDoneDto[];
 
     try {
@@ -47,7 +47,7 @@ export class WorkDoneController {
   }
 
   @Get(":id")
-  async getWorkDone(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
+  async getWorkDone(@Param("id", ParseIntPipe) id: number, @Query("userId") userId?: number) {
     let serviceResult: WorkDoneDto;
 
     try {

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -79,8 +79,10 @@ export class WorkDoneService extends CRUDService<WorkDone> {
     sqlQueryString = sqlQueryString
       .innerJoinAndMapMany("wd", WorkTodo, "wt", "wd.work_todo_id = wt.id")
       .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
-      .where("wd.user_id = :userId", { userId: querystringInput.userId })
-      .andWhere("wd.work_todo_id in (:workTodoIds)", { workTodoIds: workTodoIdArray });
+      .where("wd.work_todo_id in (:workTodoIds)", { workTodoIds: workTodoIdArray });
+    if (querystringInput.userId) {
+      sqlQueryString = sqlQueryString.where("wd.user_id = :userId", { userId: querystringInput.userId });
+    }
 
     // query string 을 사용해 SELECT 수행
     /*

--- a/src/work-todo/work-todo-querystring.dto.ts
+++ b/src/work-todo/work-todo-querystring.dto.ts
@@ -1,14 +1,14 @@
 import { WorkTodoQuerystringType } from "./work-todo-querystring.type";
 
 export class WorkTodoQuerystringDto implements WorkTodoQuerystringType {
-  constructor(userId: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
+  constructor(userId?: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
     this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
     this.activeDate = activeDate ?? undefined;
     this.maximumActiveDate = maximumActiveDate ?? undefined;
   }
 
-  userId: number;
+  userId?: number;
 
   courseId?: number;
 

--- a/src/work-todo/work-todo-querystring.dto.ts
+++ b/src/work-todo/work-todo-querystring.dto.ts
@@ -1,12 +1,18 @@
 import { WorkTodoQuerystringType } from "./work-todo-querystring.type";
 
 export class WorkTodoQuerystringDto implements WorkTodoQuerystringType {
-  constructor(userId: number, courseId: number) {
+  constructor(userId: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
     this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
+    this.activeDate = activeDate ?? undefined;
+    this.maximumActiveDate = maximumActiveDate ?? undefined;
   }
 
   userId: number;
 
   courseId?: number;
+
+  activeDate: Date;
+
+  maximumActiveDate: Date;
 }

--- a/src/work-todo/work-todo-querystring.type.ts
+++ b/src/work-todo/work-todo-querystring.type.ts
@@ -1,5 +1,5 @@
 export type WorkTodoQuerystringType = {
-  userId: number;
+  userId?: number;
   courseId?: number;
   activeDate?: Date;
   maximumActiveDate?: Date;

--- a/src/work-todo/work-todo-querystring.type.ts
+++ b/src/work-todo/work-todo-querystring.type.ts
@@ -1,4 +1,6 @@
 export type WorkTodoQuerystringType = {
   userId: number;
   courseId?: number;
+  activeDate?: Date;
+  maximumActiveDate?: Date;
 };

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -34,11 +34,16 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
 
   // TODO: Custom pipe 만들어 param을 선택 사항 가능하게 만들기
   @Get()
-  async getWorkTodosByConditions(@Query("userId") userId: number, @Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(
+    @Query("userId") userId: number,
+    @Query("courseId") courseId?: number,
+    @Query("activeDate") activeDate?: Date,
+    @Query("maximumActiveDate") maximumActiveDate?: Date
+  ) {
     let serviceResult: WorkTodoGetDto[];
 
     try {
-      const querystringInput = new WorkTodoQuerystringDto(userId, courseId);
+      const querystringInput = new WorkTodoQuerystringDto(userId, courseId, activeDate, maximumActiveDate);
 
       // 할일 리스트 저장
       serviceResult = await this.workTodoService.getWorkTodosByConditions(querystringInput);

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -35,7 +35,7 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
   // TODO: Custom pipe 만들어 param을 선택 사항 가능하게 만들기
   @Get()
   async getWorkTodosByConditions(
-    @Query("userId") userId: number,
+    @Query("userId") userId?: number,
     @Query("courseId") courseId?: number,
     @Query("activeDate") activeDate?: Date,
     @Query("maximumActiveDate") maximumActiveDate?: Date

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -30,7 +30,7 @@ Content-Type: application/json
 GET {{Host}}/{{Router}}?userId=
 
 ### work_todo 조건에 알맞은 리스트 가져오기
-GET {{Host}}/{{Router}}?userId=&courseId=&activeDate=
+GET {{Host}}/{{Router}}?userId=&courseId=&activeDate=&maximumActiveDate=
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/1?userid=

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -30,7 +30,7 @@ Content-Type: application/json
 GET {{Host}}/{{Router}}?userId=
 
 ### work_todo 조건에 알맞은 리스트 가져오기
-GET {{Host}}/{{Router}}?userId=&courseId=
+GET {{Host}}/{{Router}}?userId=&courseId=&activeDate=
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/1?userid=

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -122,9 +122,12 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     /*
         SELECT *
         FROM work_todo wt
-        WHERE wt.course_id = ? AND wt.user_id = ?
     */
-    let sqlQueryString = getRepository(WorkTodo).createQueryBuilder("wt").where("wt.user_id = :userId", { userId: querystringInput.userId });
+    let sqlQueryString = getRepository(WorkTodo).createQueryBuilder("wt");
+
+    if (querystringInput.userId) {
+      sqlQueryString = sqlQueryString.andWhere("wt.user_id = :userId", { userId: querystringInput.userId });
+    }
     if (querystringInput.courseId) {
       sqlQueryString = sqlQueryString.andWhere("wt.course_id = :courseId", { courseId: querystringInput.courseId });
     }


### PR DESCRIPTION
# 변경 내역

1. activeDate, maximumActiveDate 정보를 querystring으로 입력시 해당 기간동안 반복되는 work-todo 리스트 반환 기능 추가
2. HTTP Get 요청시 JWT 디코딩 기능 삭제

# 변경 이유

1. NextJS 에서 해당 기능 개발 요구

# 테스트 방법

1. HTTP Get 요청시 activeDate, maximumActiveDate 정보를 입력해서 recurringCycleDate work-todo가 반복되어 리스트 형태로 전달되는지 확인한다.
2. HTTP Get 요청시 JWT 없이도 응답이 오는지 확인합니다.