### PR TITLE
Course 리스트 가져오는 메소드 이름 변경

### DIFF
--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -34,14 +34,14 @@ export class CourseController extends CRUDController<Course> {
   }
 
   @Get()
-  async getAllCourses(@Query("userId") userId?: number) {
+  async getCoursesByConditions(@Query("userId") userId?: number) {
     let serviceResult: CourseGetDto[];
 
     try {
       const querystringInput = new CourseQuerystringDto(userId);
 
       // 코스 리스트 저장
-      serviceResult = await this.courseService.getAllCourses(querystringInput);
+      serviceResult = await this.courseService.getCoursesByConditions(querystringInput);
     } catch (error) {
       // 동작에 실패한 경우 Catch 구문에 예외를 넘김
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/course/course.http
+++ b/src/course/course.http
@@ -1,7 +1,10 @@
 @Host = http://localhost:3003
 @Router = courses
 
-### course 리스트 조회
+### course 정보 전체 조회
+GET {{Host}}/{{Router}}
+
+### course 조건으로 조회
 GET {{Host}}/{{Router}}?userId=
 
 ### course 생성

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -63,7 +63,7 @@ export class CourseService extends CRUDService<Course> {
     await this.create(courseEntities);
   }
 
-  async getAllCourses(querystringInput: CourseQuerystringDto): Promise<CourseGetDto[]> {
+  async getCoursesByConditions(querystringInput: CourseQuerystringDto): Promise<CourseGetDto[]> {
     const courseEntitiesFilter: Course[] = new Array<Course>();
     courseEntitiesFilter.push(new Course(undefined, undefined, undefined, querystringInput.userId, undefined, undefined, undefined, undefined, undefined));
     const courseEntitiesResult = await this.find(courseEntitiesFilter);


### PR DESCRIPTION
# 변경 내역

1. HTTP GET 요청이 발생했을떄 course 리스트를 가져오는 메소드의 이름을 변경

# 변경 사유

1. 타 서비스 개발자의 요청으로 course리스트 조회시 userId 값에 따른 필터링 기능이 필요한데, 해당 기능이 이미 구현되어 있어 관련 메소드 이름만 변경

# 테스트 방법

1. course 조회시 userId값을 querystring으로 입력해 해당 userId값에 해당되는 course만 반환되는지 확인한다.