### PR TITLE
work-todo id 사용해 가져오는 기능 추가

### DIFF
--- a/src/work-todo/work-todo-querystring.dto.ts
+++ b/src/work-todo/work-todo-querystring.dto.ts
@@ -1,18 +1,21 @@
 import { WorkTodoQuerystringType } from "./work-todo-querystring.type";
 
 export class WorkTodoQuerystringDto implements WorkTodoQuerystringType {
-  constructor(userId?: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
+  constructor(userId?: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date, workTodoId?: number) {
     this.userId = userId ?? undefined;
     this.courseId = courseId ?? undefined;
     this.activeDate = activeDate ?? undefined;
     this.maximumActiveDate = maximumActiveDate ?? undefined;
+    this.workTodoId = workTodoId ?? undefined;
   }
 
   userId?: number;
 
   courseId?: number;
 
-  activeDate: Date;
+  activeDate?: Date;
 
-  maximumActiveDate: Date;
+  maximumActiveDate?: Date;
+
+  workTodoId?: number;
 }

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -58,6 +58,25 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
     return serviceResult;
   }
 
+  @Get(":id")
+  async getWorkTodo(@Param("id", ParseIntPipe) id: number) {
+    let serviceResult: WorkTodoGetDto[];
+
+    try {
+      const querystringInput = new WorkTodoQuerystringDto(undefined, undefined, undefined, undefined, id);
+
+      serviceResult = await this.workTodoService.getWorkTodosByConditions(querystringInput);
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      // API에 에러를 토스
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
   @Delete(":id")
   async deleteWorkTodo(@Query("userId") userId: number, @Param("id", ParseIntPipe) id: number) {
     try {

--- a/src/work-todo/work-todo.http
+++ b/src/work-todo/work-todo.http
@@ -32,5 +32,8 @@ GET {{Host}}/{{Router}}?userId=
 ### work_todo 조건에 알맞은 리스트 가져오기
 GET {{Host}}/{{Router}}?userId=&courseId=&activeDate=&maximumActiveDate=
 
+### work_todo 1개 가져오기
+GET {{Host}}/{{Router}}/1
+
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/1?userid=

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -134,6 +134,9 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     if (querystringInput.activeDate) {
       sqlQueryString = sqlQueryString.andWhere("wt.active_date >= :activeDate", { activeDate: querystringInput.activeDate });
     }
+    if (querystringInput.workTodoId) {
+      sqlQueryString = sqlQueryString.andWhere("wt.id = :workTodoId", { workTodoId: querystringInput.workTodoId });
+    }
 
     let workTodoEntitiesFilteredResult = await sqlQueryString.getMany();
     const workTodoGetDtoArrayResult = new Array<WorkTodoGetDto>();


### PR DESCRIPTION
# 변경 내역

1. work-todo의 id값을 사용해 단일 work-todo 가져오는 기능 추가

# 변경 사유

1. @algo2000 님의 개발 요청

# 테스트 방법

1. QA서버에 배포한 다음 work-todo의 id값을 사용해 특정 work-todo만 가져오는 기능이 정상 동작하는지 확인합니다.