### PR TITLE
work-todo 조회시 courseId 가져오는 기능 추가

### DIFF
--- a/src/work-todo/work-todo-get.dto.ts
+++ b/src/work-todo/work-todo-get.dto.ts
@@ -16,6 +16,10 @@ export class WorkTodoGetDto extends WorkTodoDto implements WorkTodoGetInterface 
       if (workTodoGetInterfaceInput.color) {
         this.color = workTodoGetInterfaceInput.color ?? undefined;
       }
+
+      if (workTodoGetInterfaceInput.courseId) {
+        this.courseId = workTodoGetInterfaceInput.courseId ?? undefined;
+      }
     }
   }
 
@@ -39,4 +43,6 @@ export class WorkTodoGetDto extends WorkTodoDto implements WorkTodoGetInterface 
   color: string;
 
   repeatedDaysOfTheWeek: number[];
+
+  courseId: number;
 }

--- a/src/work-todo/work-todo-get.interface.ts
+++ b/src/work-todo/work-todo-get.interface.ts
@@ -4,4 +4,5 @@ export interface WorkTodoGetInterface extends WorkTodoType {
   courseTitle: string;
   color: string;
   repeatedDaysOfTheWeek: number[];
+  courseId: number;
 }

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -177,6 +177,7 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
 
       workTodoGetDto.courseTitle = filteredWorkTodoJoinResult[0]["c_title"];
       workTodoGetDto.color = filteredWorkTodoJoinResult[0]["c_color"];
+      workTodoGetDto.courseId = filteredWorkTodoJoinResult[0]["c_id"];
       workTodoGetDtoArrayResult.push(workTodoGetDto);
     }
 


### PR DESCRIPTION
# 변경 내역

1. work-todo 조회시 반환되는 json 객체 내부에 course_id 값 추가

# 변경 사유

1. @algo2000 님의 기능 요청

# 테스트 방법

1. API Gateway를 통해서 서비스 호출시 courseId값이 json 내부에 존재하는지 확인합니다.