### PR TITLE
DB Insert 후 PK 가져오던 SQL SELECT 구문 삭제

### DIFF
--- a/src/color/color.service.ts
+++ b/src/color/color.service.ts
@@ -14,13 +14,13 @@ export class ColorService extends CRUDService<Color> {
     super(colorRepository);
   }
 
-  async createColor(colorDtoInput: ColorDto): Promise<void> {
+  async createColor(colorDtoInput: ColorDto): Promise<Color> {
     const colorEntity = new Color(colorDtoInput.id);
 
     const colorEntities = new Array<Color>();
     colorEntities.push(colorEntity);
 
-    await this.create(colorEntities);
+    return (await this.create(colorEntities))[0];
   }
 
   async getAllColors(): Promise<string[]> {

--- a/src/common/crud.service.ts
+++ b/src/common/crud.service.ts
@@ -9,8 +9,8 @@ export class CRUDService<T> {
   ) {}
 
   // 1개 이상의 행 Create
-  async create(crudEntities: T[]): Promise<void> {
-    await this.crudRepository.save(crudEntities);
+  async create(crudEntities: T[]): Promise<T[]> {
+    return await this.crudRepository.save(crudEntities);
   }
 
   // 1개 행 Read

--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -19,9 +19,9 @@ export class CourseController extends CRUDController<Course> {
   @Post()
   async createCourse(@Body(new ValidationPipe({ groups: ["userInput"] })) coursePostDtoInput: CoursePostDto) {
     try {
-      await this.courseService.createCourse(coursePostDtoInput);
+      const courseEntity = await this.courseService.createCourse(coursePostDtoInput);
       await this.courseService.createNewTags(coursePostDtoInput.tags);
-      await this.courseService.createCourseTag(coursePostDtoInput);
+      await this.courseService.createCourseTag(courseEntity, coursePostDtoInput);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -32,7 +32,7 @@ export class CourseService extends CRUDService<Course> {
     super(courseRepository);
   }
 
-  async createCourse(courseDtoInput: CourseDto): Promise<void> {
+  async createCourse(courseDtoInput: CourseDto): Promise<Course> {
     const colorEntity = new Color(courseDtoInput.color);
 
     // 입력한 color 외래키의 존재 여부를 검증한다.
@@ -60,7 +60,7 @@ export class CourseService extends CRUDService<Course> {
     // 생성 시 입력된 key value를 사용해 객체에 값을 입력한다.
     courseEntities.push(courseEntity);
 
-    await this.create(courseEntities);
+    return (await this.create(courseEntities))[0];
   }
 
   async getCoursesByConditions(querystringInput: CourseQuerystringDto): Promise<CourseGetDto[]> {
@@ -143,7 +143,7 @@ export class CourseService extends CRUDService<Course> {
   }
 
   // 코스와 태그의 관계를 삽입 해 주기 위한 메소드
-  async createCourseTag(coursePostDtoInput: CoursePostDto): Promise<void> {
+  async createCourseTag(courseEntity: Course, coursePostDtoInput: CoursePostDto): Promise<void> {
     let tagEntitiesFindResult = new Array<Tag>();
 
     const inputTagEntities = new Array<Tag>();
@@ -157,29 +157,10 @@ export class CourseService extends CRUDService<Course> {
       tagEntitiesFindResult = await this.tagService.find(inputTagEntities);
     }
 
-    let courseEntitiesFindResult = new Array<Course>();
-    // 코스의 Id 값 알아오기
-    const courseEntity = new Course(
-      undefined,
-      new Course(coursePostDtoInput.originalCourseId, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined),
-      new Color(coursePostDtoInput.color),
-      coursePostDtoInput.userId,
-      coursePostDtoInput.startDate,
-      coursePostDtoInput.endDate,
-      coursePostDtoInput.explanation,
-      coursePostDtoInput.title,
-      coursePostDtoInput.likeCount
-    );
-
-    courseEntitiesFindResult.push(courseEntity);
-    courseEntitiesFindResult = await this.find(courseEntitiesFindResult);
-
     // courseTag 관련 삽입 메소드 호출
     const courseTagEntities = new Array<CourseTag>();
     for (const tag of tagEntitiesFindResult) {
       const tagEntity = new Tag(tag.id, undefined);
-      // 검색된 course는 무조껀 1개라는 전제가 깔려있다.
-      const courseEntity = new Course(courseEntitiesFindResult[0].id, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
       const courseTagEntity = new CourseTag(undefined, courseEntity, tagEntity);
 
       courseTagEntities.push(courseTagEntity);

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -21,7 +21,7 @@ export class WorkDoneService extends CRUDService<WorkDone> {
     super(workDoneRepository);
   }
 
-  async createWorkDone(workDoneTypeInput: WorkDoneType): Promise<void> {
+  async createWorkDone(workDoneTypeInput: WorkDoneType): Promise<WorkDone> {
     // 올바른 FK인지 검증한다.
     const workTodoEntitiesInput = new Array<WorkTodo>();
     const workTodoEntityInput = new WorkTodo(workDoneTypeInput.workTodoId, undefined, undefined, undefined, undefined, undefined);
@@ -49,7 +49,7 @@ export class WorkDoneService extends CRUDService<WorkDone> {
 
     workDoneEntitiesInput.push(workDoneEntityInput);
 
-    await this.create(workDoneEntitiesInput);
+    return (await this.create(workDoneEntitiesInput))[0];
   }
 
   async getWorkDonesByConditions(querystringInput: WorkDoneQuerystringDto): Promise<WorkDoneDto[]> {

--- a/src/work-todo/work-todo.controller.ts
+++ b/src/work-todo/work-todo.controller.ts
@@ -19,8 +19,8 @@ export class WorkTodoController extends CRUDController<WorkTodo> {
   @Post()
   async createWorkTodo(@Body(new ValidationPipe({ groups: ["userInput"] })) workTodoPostInput: WorkTodoPostDto) {
     try {
-      await this.workTodoService.createWorkTodo(workTodoPostInput);
-      await this.workTodoService.createRepeatedDaysOfTheWeek(workTodoPostInput);
+      const workTodoEntity = await this.workTodoService.createWorkTodo(workTodoPostInput);
+      await this.workTodoService.createRepeatedDaysOfTheWeek(workTodoEntity, workTodoPostInput);
     } catch (error) {
       // API에 에러를 토스
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -27,7 +27,7 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     super(workTodoRepository);
   }
 
-  async createWorkTodo(workTodoPostDtoInput: WorkTodoPostDto): Promise<void> {
+  async createWorkTodo(workTodoPostDtoInput: WorkTodoPostDto): Promise<WorkTodo> {
     // 올바른 FK인지 검증한다.
     const courseEntitiesInput = new Array<Course>();
     const courseEntityInput = new Course(workTodoPostDtoInput.courseId, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
@@ -52,37 +52,21 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
 
     workTodoEntities.push(workTodoEntity);
 
-    await this.create(workTodoEntities);
+    return (await this.create(workTodoEntities))[0];
   }
 
-  async createRepeatedDaysOfTheWeek(workTodoPostDtoInput: WorkTodoPostDto): Promise<void> {
-    // createWorkTodo 메소드에서 생성된 work todo의 id 값을 알아낸다.
-    let workTodoEntitiesFindResult = new Array<WorkTodo>();
-    const workTodoEntity = new WorkTodo(
-      undefined,
-      new Course(workTodoPostDtoInput.id, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined),
-      workTodoPostDtoInput.recurringCycleDate,
-      workTodoPostDtoInput.title,
-      workTodoPostDtoInput.explanation,
-      workTodoPostDtoInput.activeDate
-    );
-
-    workTodoEntitiesFindResult.push(workTodoEntity);
-    workTodoEntitiesFindResult = await this.find(workTodoEntitiesFindResult);
-
+  async createRepeatedDaysOfTheWeek(workTodoEntity: WorkTodo, workTodoPostDtoInput: WorkTodoPostDto): Promise<void> {
     const repeatedDaysOfTheWeekEntities = new Array<RepeatedDaysOfTheWeek>();
 
     // 사용자가 입력한 반복 요일 정보를 요일 entity 객체 배열에 저장
     for (const daysOfTheWeekItem of workTodoPostDtoInput.repeatedDaysOfTheWeek) {
-      for (const workTodoEntityItem of workTodoEntitiesFindResult) {
-        const repeatedDaysOfTheWeekEntity = new RepeatedDaysOfTheWeek(
-          undefined,
-          new WorkTodo(workTodoEntityItem.id, undefined, undefined, undefined, undefined, undefined),
-          daysOfTheWeekItem
-        );
+      const repeatedDaysOfTheWeekEntity = new RepeatedDaysOfTheWeek(
+        undefined,
+        new WorkTodo(workTodoEntity.id, undefined, undefined, undefined, undefined, undefined),
+        daysOfTheWeekItem
+      );
 
-        repeatedDaysOfTheWeekEntities.push(repeatedDaysOfTheWeekEntity);
-      }
+      repeatedDaysOfTheWeekEntities.push(repeatedDaysOfTheWeekEntity);
     }
 
     await this.repeatedDaysOfTheWeekService.create(repeatedDaysOfTheWeekEntities);


### PR DESCRIPTION
# 변경 내역

1. color 테이블에 insert하는 service 코드내 반환값 추가
2. course 테이블에 insert하는 service 코드내 반환값 추가
3. work-todo 테이블에 insert하는 service 코드내 반환값 추가
4. work-done 테이블에 insert하는 service 코드내 반환값 추가
5. course 테이블의 PK를 FK로 가지는 테이블 Insert시 ORM에서 넘겨준 PK 사용
6. work-todo 테이블의 PK를 FK로 가지는 테이블 Insert시 ORM에서 넘겨준 PK 사용

# 변경 사유

1. course import 기능 구현시 용의한 기능 개발을 하기 위해 기존 코드를 리팩토링 해야 할 필요성 존재

# 테스트 방법

1. color 테이블에 insert 하는 API endpoint가 정상 동작하는지 확인합니다.
2. work-done 테이블에 insert 하는 API endpoint가 정상 동작하는지 확인합니다.
3. work-todo 테이블에 insert 하는 API endpoint가 정상 동작하는지 확인합니다.
4. course 테이블에 insert 하는 API endpoint가 정상 동작하는지 확인합니다.