### PR TITLE
work_done 내부의 action_date 컬럼 not null하게 변경

### DIFF
--- a/src/entity/work-done.entity.ts
+++ b/src/entity/work-done.entity.ts
@@ -79,8 +79,7 @@ export class WorkDone {
   @CreateDateColumn({
     type: "datetime",
     name: "action_date",
-    nullable: true,
-    default: () => null,
+    nullable: false,
   })
   actionDate: Date;
 }

--- a/src/migrations/1638951784430-WorkDoneSchemaModify.ts
+++ b/src/migrations/1638951784430-WorkDoneSchemaModify.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WorkDoneSchemaModify1638951784430 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`use belf;`);
+    queryRunner.query(`DELETE FROM work_done WHERE action_date IS NULL;`);
+    queryRunner.query(`ALTER TABLE work_done MODIFY COLUMN action_date DATETIME(6) NOT NULL;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query("use belf;");
+    queryRunner.query(`ALTER TABLE work_done MODIFY COLUMN DATETIME(6)`);
+  }
+}

--- a/src/work-done/work-done.type.ts
+++ b/src/work-done/work-done.type.ts
@@ -1,8 +1,8 @@
 export type WorkDoneType = {
-  id: number;
-  title: string;
-  content: string;
-  userId: number;
-  workTodoId: number;
-  actionDate: Date;
+  id?: number;
+  title?: string;
+  content?: string;
+  userId?: number;
+  workTodoId?: number;
+  actionDate?: Date;
 };

--- a/src/work-done/work-done.type.ts
+++ b/src/work-done/work-done.type.ts
@@ -1,8 +1,8 @@
 export type WorkDoneType = {
-  id?: number;
-  title?: string;
-  content?: string;
-  userId?: number;
-  workTodoId?: number;
-  actionDate?: Date;
+  id: number;
+  title: string;
+  content: string;
+  userId: number;
+  workTodoId: number;
+  actionDate: Date;
 };


### PR DESCRIPTION
# 변경 내역

1. work_done 테이블 내부의 action_date 컬럼을 not null 하게 변경

# 변경 사유

1. work_done은 한 일을 저장할 때만 insert가 발생하기 때문에 action_date 컬럼이 비어있을 리가 없음

# 테스트 방법

1. API Gateway를 통해서 workDone 객체 생성시 actionDate를 HTTP Request body에서 뺀 다음 요청을 보내 정상 동작하는지 확인한다.