### PR TITLE
work-done 생성시 기본값으로 현재 시간 들어가도록 변경

### DIFF
--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -44,7 +44,7 @@ export class WorkDoneService extends CRUDService<WorkDone> {
       workDoneTypeInput.content,
       workDoneTypeInput.userId,
       workTodoEntityInput,
-      workDoneTypeInput.actionDate
+      workDoneTypeInput.actionDate ?? undefined
     );
 
     workDoneEntitiesInput.push(workDoneEntityInput);

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -44,6 +44,7 @@ export class WorkDoneService extends CRUDService<WorkDone> {
       workDoneTypeInput.content,
       workDoneTypeInput.userId,
       workTodoEntityInput,
+      // DBMS에서 default값으로 현재 시간을 입력한다.
       workDoneTypeInput.actionDate ?? undefined
     );
 


### PR DESCRIPTION
# 변경 내역

1. work-done insert시 기본값으로 현재 시간이 들어가도록 코드 수정

# 변경 사유

1. work-done은 한 일을 수행할 떄 마다 추가되는 것 이므로 기본값으로 현재 시간이 입력 되어야 함

# 테스트 방법

1. work-done을 추가하는 API endpoint 호출시 actionDate key를 body에서 뺀 다음 정상적으로 work-done이 생성되는지 확인한다.