### PR TITLE
work-todo 컬럼값으로 삭제 구분 기능 추가

### DIFF
--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -68,4 +68,10 @@ export class WorkTodo {
     name: "user_id",
   })
   userId: number;
+
+  @Column({
+    name: "is_delete",
+    default: false,
+  })
+  isDelete: boolean;
 }

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -182,7 +182,16 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
       throw new HttpException({ data: "조건을 만족하는 데이터가 없습니다.", status: HttpStatus.BAD_REQUEST }, HttpStatus.BAD_REQUEST);
     }
 
-    await this.delete(workTodoEntitiesInput);
+    const workTodoIds = workTodoFindResult.map((workTodo) => {
+      return workTodo.id;
+    });
+
+    const sqlQueryString = getRepository(WorkTodo)
+      .createQueryBuilder("wt")
+      .update(WorkTodo)
+      .set({ isDelete: true })
+      .where("id in (:workTodoIds)", { workTodoIds: workTodoIds });
+    await sqlQueryString.execute();
   }
 
   convertWorkDones(workDoneEntities: WorkDone[], courseEntity: Course): WorkTodo[] {

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -109,7 +109,7 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
         SELECT *
         FROM work_todo wt
     */
-    let sqlQueryString = getRepository(WorkTodo).createQueryBuilder("wt");
+    let sqlQueryString = getRepository(WorkTodo).createQueryBuilder("wt").where("wt.is_delete = 0");
 
     if (querystringInput.userId) {
       sqlQueryString = sqlQueryString.andWhere("wt.user_id = :userId", { userId: querystringInput.userId });


### PR DESCRIPTION
# 변경 내역

1. work_todo 테이블 내 삭제 구분하는 is_delete 컬럼 추가
2. work_todo 리스트 조회시 is_delete 플래그가 true인 경우 리스트에서 제외하는 기능 추가

# 변경 사유

1. @algo2000 님의 요청

# 테스트 방법

1. work-todo 객체를 지우는 HTTP API 호출시 컬럼이 true로 변경되는지 확인한다.
2. work_todo 테이블 내부의 is_delete 컬럼이 false인 경우 리스트 반환값에서 미포함 되는지 확인한다.