### PR TITLE
work-todo 내부에 기존 explanation 데이터 입력

### DIFF
--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -60,9 +60,10 @@ export class CourseController extends CRUDController<Course> {
         const workDoneDtosResult = await this.workDoneService.getWorkDonesByConditions(
           new WorkDoneQuerystringDto(undefined, coursePostDtoInput.originalCourseId)
         );
-        const convertedWorkTodoEntities = this.workTodoService.convertWorkDones(WorkDone.dtosConstructor(workDoneDtosResult), courseEntity);
+        const convertedWorkTodoEntities = await this.workTodoService.convertWorkDones(WorkDone.dtosConstructor(workDoneDtosResult), courseEntity);
         await this.workTodoService.create(convertedWorkTodoEntities);
       }
+
       // course 생성
       else {
         courseEntity = await this.courseService.createCourse(coursePostDtoInput);

--- a/src/course/course.http
+++ b/src/course/course.http
@@ -35,8 +35,6 @@ Content-Type: application/json
 
 {
     "originalCourseId": 1,
-    "startDate": "2021-12-07",
-    "endDate": "2021-12-10",
     "userId": 1
 }
 


### PR DESCRIPTION
# 변경 내역

1. course import 기능 사용시 work-done → work-todo 변경되는 work-todo의 explanation 데이터를  리지널 work-todo의 explanation 값을 입력

# 변경 사유

1. @algo2000 님의 요청

# 테스트 방법

1. course import 기능을 사용한 다음 work-done → work-todo 변환된 데이터의 explanation 컬럼에 원래의 explanation 데이터가 들어가있는지 확인한다.