### PR TITLE
코스 제목 검색시 색상 정보 조회 않되는 문제 수정

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -103,8 +103,8 @@ export class CourseService extends CRUDService<Course> {
     const sqlQueryString = getRepository(Course)
       .createQueryBuilder("c")
       .where("c.title like :keyword", { keyword: `%${keyword}%` });
-    const courseEntitiesResult = await sqlQueryString.getMany();
-    const joinResult = this.courseJoiner(courseEntitiesResult, undefined);
+    const courseEntitiesResult = await this.find(await sqlQueryString.getMany());
+    const joinResult = await this.courseJoiner(courseEntitiesResult, undefined);
 
     return joinResult;
   }


### PR DESCRIPTION
# 변경 내역

1. 코스 제목 검색시 color 정보 조회되게 수정

# 변경 사유

1. @algo2000 님의 버그 제보

# 테스트 방법

1. 코스 제목을 통해 코스 리스트를 반환받은 다음, 코스 객체에 color 정보가 존재하는지 확인한다.