### PR TITLE
course 조회시 user email 정보 반환 기능 추가

### DIFF
--- a/src/course/course-get.dto.ts
+++ b/src/course/course-get.dto.ts
@@ -17,7 +17,7 @@ export class CourseGetDto extends CourseDto implements CourseGetInterface {
     }
   }
 
-  static entityConstructor(courseEntityInput?: Course, tagEntitiesInput?: Tag[]) {
+  static entityConstructor(courseEntityInput?: Course, tagEntitiesInput?: Tag[], userEmail?: string) {
     const courseDto = super.entityConstructor(courseEntityInput);
     const courseGetDto = new CourseGetDto(courseDto as CourseGetInterface);
 
@@ -30,8 +30,12 @@ export class CourseGetDto extends CourseDto implements CourseGetInterface {
       }
     }
 
+    courseGetDto.userEmail = userEmail ?? undefined;
+
     return courseGetDto;
   }
 
   tags: TagDto[];
+
+  userEmail: string;
 }

--- a/src/course/course-get.interface.ts
+++ b/src/course/course-get.interface.ts
@@ -4,4 +4,5 @@ import { TagType } from "src/tag/tag.type";
 
 export interface CourseGetInterface extends CourseType {
   tags: TagType[];
+  userEmail: string;
 }


### PR DESCRIPTION
# 변경 내역

1. course 반환 양식 제작시마다 user의 email 정보를 가져와 폼에 저장하는 기능 추가
2. user의 email 정보를 HTTP GET 반환 폼에 추가

# 변경 사유

1. @algo2000 님의 요청

# 테스트 방법

1. course 정보를 조회하는 API endpoint를 호출했을 때 userEmail 정보가 반환되는지 확인한다.