### PR TITLE
코스 제목 검색 키워드 존재하지 않는 경우 비어있는 배열 반환

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -106,7 +106,7 @@ export class CourseService extends CRUDService<Course> {
       const sqlQueryString = getRepository(Course)
         .createQueryBuilder("c")
         .where("c.title like :keyword", { keyword: `%${keyword}%` });
-      const courseEntitiesResult = await this.find(await sqlQueryString.getMany());
+      const courseEntitiesResult = await sqlQueryString.getMany();
       joinResult = await this.courseJoiner(courseEntitiesResult, undefined);
     } else {
       joinResult = new Array<CourseGetDto>();

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -100,11 +100,17 @@ export class CourseService extends CRUDService<Course> {
   }
 
   async getCourseBySearch(keyword: string) {
-    const sqlQueryString = getRepository(Course)
-      .createQueryBuilder("c")
-      .where("c.title like :keyword", { keyword: `%${keyword}%` });
-    const courseEntitiesResult = await this.find(await sqlQueryString.getMany());
-    const joinResult = await this.courseJoiner(courseEntitiesResult, undefined);
+    let joinResult: CourseGetDto[];
+
+    if (keyword) {
+      const sqlQueryString = getRepository(Course)
+        .createQueryBuilder("c")
+        .where("c.title like :keyword", { keyword: `%${keyword}%` });
+      const courseEntitiesResult = await this.find(await sqlQueryString.getMany());
+      joinResult = await this.courseJoiner(courseEntitiesResult, undefined);
+    } else {
+      joinResult = new Array<CourseGetDto>();
+    }
 
     return joinResult;
   }

--- a/src/entity/course.entity.ts
+++ b/src/entity/course.entity.ts
@@ -57,7 +57,6 @@ export class Course {
   @ManyToOne(() => Color, (color) => color.id, {
     onDelete: "SET NULL",
     nullable: true,
-    eager: true,
   })
   @JoinColumn({ name: "color" })
   color: Color;


### PR DESCRIPTION
# 변경 내역

1. course 제목 검색 키워드 없는경우 빈 리스트 반환하게 변경

# 변경 사유

1. 검색 키워드가 존재하지 않는 경우 코스 전체 리스트가 반환되어 정상 동작 여부를 판별하기 어렵게 함

# 테스트 방법

1. course 키워드 검색 API endpoint를 검색 키워드로 호출하고, 검색 키워드가 없는 상태로 호출해 반환값의 차이를 비교한다.