### PR TITLE
TypeORM 타임존 옵션을 Zulu time으로 변경

### DIFF
--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -1,5 +1,6 @@
 const DatabaseConfig = () => ({
   type: "mysql",
+  timezone: "Z",
   entities: ["dist/**/*.entity{.ts,.js}"],
   synchronize: Boolean(process.env.DB_SYNCHRONIZE),
   migrationsTableName: "typeorm_migrations",


### PR DESCRIPTION
# 변경 내역

1. NestJS에서 구동되는 TypeORM의 기본 timezone 옵션을 Zulu time(UTC +0)으로 변경

# 변경 사유

1. Front 웹 서버와 Backend 웹 서버간 시차 차이 문제 해결

# 테스트 방법

1. work-todo 생성시 시간 정보를 입력하지 않은 상태로 생성후 DB에서 시간 정보가 00:00 인지 확인한다.