### PR TITLE
유저 탈퇴 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { WorkTodoModule } from "./work-todo/work-todo.module";
 import { RepeatedDaysOfTheWeekModule } from "./repeated-days-of-the-week/repeated-days-of-the-week.module";
 import { WorkDoneModule } from "./work-done/work-done.module";
 import { CourseImportationModule } from "./course-importation/course-importation.module";
+import { UserModule } from "./user/user.module";
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { CourseImportationModule } from "./course-importation/course-importation
     RepeatedDaysOfTheWeekModule,
     WorkDoneModule,
     CourseImportationModule,
+    UserModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/course-importation/course-importation.service.ts
+++ b/src/course-importation/course-importation.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { getRepository, Repository } from "typeorm";
 
 import { CourseImportationDto } from "./course-importation.dto";
 
@@ -44,5 +44,9 @@ export class CourseImportationService extends CRUDService<CourseImportation> {
     courseImportationEntities.push(courseImportationEntity);
 
     return (await this.create(courseImportationEntities))[0];
+  }
+
+  async withdrawalUser(userId: number) {
+    await getRepository(CourseImportation).createQueryBuilder("ci").delete().where("ci.user_id = :userId", { userId: userId }).execute();
   }
 }

--- a/src/course-importation/course-importation.service.ts
+++ b/src/course-importation/course-importation.service.ts
@@ -47,6 +47,6 @@ export class CourseImportationService extends CRUDService<CourseImportation> {
   }
 
   async withdrawalUser(userId: number) {
-    await getRepository(CourseImportation).createQueryBuilder("ci").delete().where("ci.user_id = :userId", { userId: userId }).execute();
+    await getRepository(CourseImportation).createQueryBuilder("ci").delete().from(CourseImportation).where("user_id = :userId", { userId: userId }).execute();
   }
 }

--- a/src/course/course.http
+++ b/src/course/course.http
@@ -39,4 +39,4 @@ Content-Type: application/json
 }
 
 ### course 삭제
-DELETE {{Host}}/{{Router}}/courses/1?userId=
+DELETE {{Host}}/{{Router}}/1?userId=

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -259,6 +259,6 @@ export class CourseService extends CRUDService<Course> {
   }
 
   async withdrawalUser(userId: number) {
-    await getRepository(Course).createQueryBuilder("c").delete().where("c.user_id = :userId", { userId: userId }).execute();
+    await getRepository(Course).createQueryBuilder("c").delete().from(Course).where("user_id = :userId", { userId: userId }).execute();
   }
 }

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -257,4 +257,8 @@ export class CourseService extends CRUDService<Course> {
 
     await this.courseTagService.create(courseTagEntities);
   }
+
+  async withdrawalUser(userId: number) {
+    await getRepository(Course).createQueryBuilder("c").delete().where("c.user_id = :userId", { userId: userId }).execute();
+  }
 }

--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -32,7 +32,7 @@ export class WorkTodo {
   id: number;
 
   @ManyToOne(() => Course, (course) => course.id, {
-    onDelete: "CASCADE",
+    onDelete: "SET NULL",
     eager: true,
   })
   @JoinColumn({ name: "course_id" })

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { UserController } from "./user.controller";
+
+describe("UserController", () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from "@nestjs/common";
+
+@Controller("users")
+export class UserController {}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -22,10 +22,10 @@ export class UserController {
   @Delete(":userId")
   async withdrawarUser(@Param("userId", ParseIntPipe) userId: number) {
     try {
-      await this.courseService.withdrawalUser(userId);
-      await this.courseImportationService.withdrawalUser(userId);
-      await this.workTodoService.withdrawalUser(userId);
       await this.workDoneService.withdrawalUser(userId);
+      await this.workTodoService.withdrawalUser(userId);
+      await this.courseImportationService.withdrawalUser(userId);
+      await this.courseService.withdrawalUser(userId);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,37 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Delete, HttpException, Param, ParseIntPipe } from "@nestjs/common";
+
+import { getErrorHttpStatusCode, getErrorMessage } from "src/common/lib/error";
+
+import { CourseImportationService } from "src/course-importation/course-importation.service";
+
+import { CourseService } from "src/course/course.service";
+
+import { WorkDoneService } from "src/work-done/work-done.service";
+
+import { WorkTodoService } from "src/work-todo/work-todo.service";
 
 @Controller("users")
-export class UserController {}
+export class UserController {
+  constructor(
+    private readonly courseService: CourseService,
+    private readonly courseImportationService: CourseImportationService,
+    private readonly workTodoService: WorkTodoService,
+    private readonly workDoneService: WorkDoneService
+  ) {}
+
+  @Delete(":userId")
+  async withdrawarUser(@Param("userId", ParseIntPipe) userId: number) {
+    try {
+      await this.courseService.withdrawalUser(userId);
+      await this.courseImportationService.withdrawalUser(userId);
+      await this.workTodoService.withdrawalUser(userId);
+      await this.workDoneService.withdrawalUser(userId);
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      // API에 에러를 토스
+      throw new HttpException(message, httpStatusCode);
+    }
+  }
+}

--- a/src/user/user.http
+++ b/src/user/user.http
@@ -1,3 +1,5 @@
 @Host = http://localhost:3003
 @Router = users
 
+### user 회원탈퇴
+DELETE {{Host}}/{{Router}}/1

--- a/src/user/user.http
+++ b/src/user/user.http
@@ -1,0 +1,3 @@
+@Host = http://localhost:3003
+@Router = users
+

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+
+import { UserService } from "./user.service";
+import { UserController } from "./user.controller";
+
+@Module({
+  providers: [UserService],
+  controllers: [UserController],
+})
+export class UserModule {}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,8 +3,18 @@ import { Module } from "@nestjs/common";
 import { UserService } from "./user.service";
 import { UserController } from "./user.controller";
 
+import { CourseModule } from "src/course/course.module";
+
+import { CourseImportationModule } from "src/course-importation/course-importation.module";
+
+import { WorkTodoModule } from "src/work-todo/work-todo.module";
+
+import { WorkDoneModule } from "src/work-done/work-done.module";
+
 @Module({
+  imports: [CourseModule, CourseImportationModule, WorkTodoModule, WorkDoneModule],
   providers: [UserService],
   controllers: [UserController],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { UserService } from "./user.service";
+
+describe("UserService", () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class UserService {}

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -148,4 +148,8 @@ export class WorkDoneService extends CRUDService<WorkDone> {
 
     await this.delete(workDoneEntitiesInput);
   }
+
+  async withdrawalUser(userId: number) {
+    await getRepository(WorkDone).createQueryBuilder("wd").delete().where("wd.user_id = :userId", { userId: userId }).execute();
+  }
 }

--- a/src/work-done/work-done.service.ts
+++ b/src/work-done/work-done.service.ts
@@ -150,6 +150,6 @@ export class WorkDoneService extends CRUDService<WorkDone> {
   }
 
   async withdrawalUser(userId: number) {
-    await getRepository(WorkDone).createQueryBuilder("wd").delete().where("wd.user_id = :userId", { userId: userId }).execute();
+    await getRepository(WorkDone).createQueryBuilder("wd").delete().from(WorkDone).where("user_id = :userId", { userId: userId }).execute();
   }
 }

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -231,4 +231,8 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
 
     return workTodoEntities;
   }
+
+  async withdrawalUser(userId: number) {
+    await getRepository(WorkTodo).createQueryBuilder("wt").update(WorkTodo).set({ isDelete: true }).where("wt.user_id = :userId", { userId: userId }).execute();
+  }
 }

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -233,6 +233,6 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
   }
 
   async withdrawalUser(userId: number) {
-    await getRepository(WorkTodo).createQueryBuilder("wt").update(WorkTodo).set({ isDelete: true }).where("wt.user_id = :userId", { userId: userId }).execute();
+    await getRepository(WorkTodo).createQueryBuilder("wt").update(WorkTodo).set({ isDelete: true }).where("user_id = :userId", { userId: userId }).execute();
   }
 }


### PR DESCRIPTION
# 변경 내역

1. 유저 탈퇴 시 관련 데이터 삭제를 위한 기능 추가

# 변경 사유

1. 유저 탈퇴시 한국인터넷진흥원의 기능 구현 안내서에 따라 관련 데이터를 파기 처리해야 할 필요성 존재

# 테스트 방법

1. 유저의 데이터를 삭제하는 API를 호출한 다음 관련 데이터가 삭제되는지 확인한다.