### PR TITLE
course가 존재하지 않는 work-todo 조회시 500 응답 수정

### DIFF
--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -134,7 +134,7 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
     */
     sqlQueryString = getRepository(WorkTodo)
       .createQueryBuilder("wt")
-      .innerJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
+      .leftJoinAndMapMany("wt", Course, "c", "wt.course_id = c.id")
       .leftJoinAndMapMany("wt", RepeatedDaysOfTheWeek, "rdotw", "wt.id = rdotw.work_todo_id");
     const workTodosJoinResult = await sqlQueryString.getRawMany();
 


### PR DESCRIPTION
# 변경 내역

1. work-todo와 course 조인시 innerJoin에서 leftJoin으로 변경

# 변경 사유

1. course 정보가 null 인경우 innerJoin이 정상적으로 수행되지 않아 빈 array가 반환되며 서버 에러의 원인이 됨

# 테스트 방법

1. work-todo 조회시 course_id 컬럼이 null인 데이터를 userId 사용해 조회한다.