### PR TITLE
course import시 오늘 날자 및 시간 + (work done 시간 및 날짜 - work-todo 시간 및 날짜) 입력하는 기능 추가

### DIFF
--- a/src/course/course.http
+++ b/src/course/course.http
@@ -26,7 +26,8 @@ Content-Type: application/json
         {
             "value": "하하하"
         }
-    ]
+    ],
+    "startDate": "2021-11-05"
 }
 
 ### course import

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -86,7 +86,7 @@ export class CourseService extends CRUDService<Course> {
       new Course(courseDtoInput.originalCourseId, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined),
       colorEntity,
       courseDtoInput.userId,
-      courseDtoInput.startDate,
+      courseDtoInput.startDate ?? new Date(),
       courseDtoInput.endDate,
       courseDtoInput.explanation,
       courseDtoInput.title,

--- a/src/entity/course.entity.ts
+++ b/src/entity/course.entity.ts
@@ -66,7 +66,6 @@ export class Course {
 
   @Column({
     type: "date",
-    nullable: true,
     name: "start_date",
   })
   startDate: Date;

--- a/src/migrations/1639657054999-CourseDeleteNullableStartDate.ts
+++ b/src/migrations/1639657054999-CourseDeleteNullableStartDate.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CourseDeleteNullableStartDate1639657054999 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`USE belf;`);
+    await queryRunner.query(`DELETE FROM course WHERE start_date IS NULL`);
+    await queryRunner.query(`ALTER TABLE course MODIFY start_date DATE NOT NULL;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`USE belf;`);
+    await queryRunner.query(`ALTER TABLE course MODIFY start_date DATE NULL;`);
+  }
+}

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -206,14 +206,12 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
         await this.findOne(new WorkTodo(workDoneEntity.workTodoId.id, undefined, undefined, undefined, undefined, undefined, undefined)),
         workDoneEntity.actionDate
       );
-      let workTodoActionDate = new Date();
-      const dayToSubstract = workDoneEntity.actionDate ?? 0;
-      // TODO: 날짜 차이 로직 구하는 기능 추가
-      // const dayDifference = Math.abs(+new Date(workDoneEntity.actionDate) - +new Date(courseEntity.originalCourseId.startDate));
-      const dayDifference = new Date();
+      let workTodoActionDate = workDoneEntity.workTodoId.activeDate;
+      // import 되는 new Date(work-done) - new Date(work-todo)
+      const dayDifference = Math.abs(+new Date(workDoneEntity.actionDate) - +new Date(workDoneEntity.workTodoId.activeDate));
 
-      if (dayToSubstract) {
-        workTodoActionDate = new Date(+new Date(dayDifference) + +new Date(courseEntity.startDate));
+      if (dayDifference) {
+        workTodoActionDate = new Date(new Date(+new Date(dayDifference) + +new Date()));
       }
 
       const workTodoEntity = new WorkTodo(


### PR DESCRIPTION
# 변경 내역

1. 코스 import시 work-done에서 변환된 work-todo에 기존 work-done과 work-todo간 시간 차이 더해주는 기능 추가

# 변경 사유

1. import된 course에 해당되는 work-todo를 프론트에서 날짜 기준으로 확인 하기 위해 해당 로직이 필요

# 테스트 방법

1. QA 서버에서 course import한 work-done -> work-todo 데이터가 기존 데이터간 시차만큼 오늘 날짜 기준으로 더해 졌는지 확인한다.