### PR TITLE
work-todo 내부의 courseId 옵션 cascade로 변경

### DIFF
--- a/src/entity/work-todo.entity.ts
+++ b/src/entity/work-todo.entity.ts
@@ -32,7 +32,7 @@ export class WorkTodo {
   id: number;
 
   @ManyToOne(() => Course, (course) => course.id, {
-    onDelete: "SET NULL",
+    onDelete: "CASCADE",
     eager: true,
   })
   @JoinColumn({ name: "course_id" })

--- a/src/migrations/1639667174402-WorkTodoAddFKConstraint.ts
+++ b/src/migrations/1639667174402-WorkTodoAddFKConstraint.ts
@@ -4,10 +4,60 @@ export class WorkTodoAddFKConstraint1639667174402 implements MigrationInterface 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`USE belf;`);
     await queryRunner.query(`DELETE FROM work_todo WHERE course_id IS NULL`);
+
+    // FK 제약조건 삭제
+    // 외래키 index 구하기
+    await queryRunner.query(`USE information_schema;`);
+    await queryRunner.query(`SET @foreign_key_index =
+    (
+      SELECT CONSTRAINT_NAME
+      FROM KEY_COLUMN_USAGE
+      WHERE TABLE_SCHEMA = 'belf'
+      AND TABLE_NAME = 'work_todo'
+      AND COLUMN_NAME = 'course_id'
+      );`);
+
+    // 외래키 삭제
+    await queryRunner.query(`USE belf`);
+    await queryRunner.query(`SET @queryStr = CONCAT('ALTER TABLE work_todo DROP FOREIGN KEY ', @foreign_key_index);`);
+    await queryRunner.query(`PREPARE qry from @queryStr;`);
+    await queryRunner.query(`EXECUTE qry;`);
+
+    // 외래키 재생성
+    await queryRunner.query(`SET @querystr = CONCAT('ALTER TABLE work_todo ADD CONSTRAINT ', @foreign_key_index);`);
+    await queryRunner.query(`SET @querystr = CONCAT(@querystr, ' FOREIGN KEY (course_id) REFERENCES course (id) ON DELETE CASCADE');`);
+    await queryRunner.query(`PREPARE qry from @queryStr;`);
+    await queryRunner.query(`EXECUTE qry;`);
+
+    await queryRunner.query(`USE belf;`);
     await queryRunner.query(`ALTER TABLE work_todo MODIFY course_id INT NOT NULL;`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // FK 제약조건 삭제
+    // 외래키 index 구하기
+    await queryRunner.query(`USE information_schema;`);
+    await queryRunner.query(`SET @foreign_key_index =
+    (
+      SELECT CONSTRAINT_NAME
+      FROM KEY_COLUMN_USAGE
+      WHERE TABLE_SCHEMA = 'belf'
+      AND TABLE_NAME = 'work_todo'
+      AND COLUMN_NAME = 'course_id'
+      );`);
+
+    // 외래키 삭제
+    await queryRunner.query(`USE belf`);
+    await queryRunner.query(`SET @queryStr = CONCAT('ALTER TABLE work_todo DROP FOREIGN KEY ', @foreign_key_index);`);
+    await queryRunner.query(`PREPARE qry from @queryStr;`);
+    await queryRunner.query(`EXECUTE qry;`);
+
+    // 외래키 재생성
+    await queryRunner.query(`SET @querystr = CONCAT('ALTER TABLE work_todo ADD CONSTRAINT ', @foreign_key_index);`);
+    await queryRunner.query(`SET @querystr = CONCAT(@querystr, ' FOREIGN KEY (course_id) REFERENCES course (id) ON DELETE SET NULL');`);
+    await queryRunner.query(`PREPARE qry from @queryStr;`);
+    await queryRunner.query(`EXECUTE qry;`);
+
     await queryRunner.query(`USE belf;`);
     await queryRunner.query(`ALTER TABLE work_todo MODIFY course_id INT NULL;`);
   }

--- a/src/migrations/1639667174402-WorkTodoAddFKConstraint.ts
+++ b/src/migrations/1639667174402-WorkTodoAddFKConstraint.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WorkTodoAddFKConstraint1639667174402 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`USE belf;`);
+    await queryRunner.query(`DELETE FROM work_todo WHERE course_id IS NULL`);
+    await queryRunner.query(`ALTER TABLE work_todo MODIFY course_id INT NOT NULL;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`USE belf;`);
+    await queryRunner.query(`ALTER TABLE work_todo MODIFY course_id INT NULL;`);
+  }
+}

--- a/src/work-todo/work-todo.service.ts
+++ b/src/work-todo/work-todo.service.ts
@@ -231,6 +231,6 @@ export class WorkTodoService extends CRUDService<WorkTodo> {
   }
 
   async withdrawalUser(userId: number) {
-    await getRepository(WorkTodo).createQueryBuilder("wt").update(WorkTodo).set({ isDelete: true }).where("user_id = :userId", { userId: userId }).execute();
+    await getRepository(WorkTodo).createQueryBuilder("wt").delete().from(WorkTodo).where("user_id = :userId", { userId: userId }).execute();
   }
 }


### PR DESCRIPTION
# 변경 내역

1. work-todo.entity.ts 내부의 courseId FK 제약조건을 CASCADE로 변경

# 변경 사유

1. course가 없는 work-todo 값들이 조회되는 문제 발생

# 테스트 방법

1. QA 웹 서버에서 course를 삭제했을 때 work-todo, work-done이 순차적으로 삭제되는지 확인한다.